### PR TITLE
Fix fill value floating point comparison

### DIFF
--- a/uptide/netcdf_reader.py
+++ b/uptide/netcdf_reader.py
@@ -374,7 +374,7 @@ class NetCDFInterpolator(object):
     else:
       raise NetCDFInterpolatorError("Field to extract mask from, should have 2 or 3 dimensions")
 
-    mask = numpy.where(val==fill_value,0.,1.)
+    mask = numpy.logical_not(numpy.isclose(val, fill_value))
     self._set_mask_and_dim_order(mask, dim_order)
 
   def set_field(self, field_name):


### PR DESCRIPTION
Fixes `val==fill_value` floating point comparison.
This is needed when reading fes2004 tidal model data with `netCDF4` package.