### PR TITLE
NetCDFInterpolator: fix coordinate delta computation

### DIFF
--- a/uptide/netcdf_reader.py
+++ b/uptide/netcdf_reader.py
@@ -241,10 +241,11 @@ class NetCDFInterpolator(object):
         val = self.nc.variables[field_name]
         if len(val.shape)==1:
           self.origin.append(val[0])
-          self.delta.append((val[-1]-self.origin[-1])/(N-1))
+          self.delta.append(numpy.diff(val).mean())
         elif len(val.shape)==2:
           self.origin.append(val[0,0])
-          self.delta.append((val[-1,-1]-self.origin[-1])/(N-1))
+          self.delta.append(max(numpy.diff(val, axis=0).mean(),
+                                numpy.diff(val, axis=1).mean()))
         else:
           raise NetCDFInterpolatorError("Unrecognized shape of coordinate field")
 

--- a/uptide/tidal_netcdf.py
+++ b/uptide/tidal_netcdf.py
@@ -235,7 +235,7 @@ def FESTidalInterpolator(tide, fes_file_name, ranges=None):
   # constituents available in the netCDF file
   constituents = tnci.nci.nc.variables['spectrum'][:]
   # dict that maps constituent names to indices
-  constituent_index = dict(((constituent.tostring().strip(' \x00').lower(),i) for i,constituent in enumerate(constituents)))
+  constituent_index = dict(((constituent.tostring().decode("utf-8").strip(' \x00').lower(),i) for i,constituent in enumerate(constituents)))
   # the indices of the requested constituents
   components = [constituent_index[constituent.lower()] for constituent in tide.constituents]
   tnci.load_amplitudes_and_phases_block(fes_file_name, 'Ha', components,


### PR DESCRIPTION
Previous method `delta = val[-1]-origin[-1])/(N-1)` may fail if the
coordinate array is masked (as in the case of fes2012) because `val[-1]`
is not a value.

Instead, use `numpy.diff` to compute the differences. It handles masked
arrays correctly.